### PR TITLE
Slett kriterier

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
   deploy-til-dev:
     name: Deploy til dev
     needs: bygg-og-push-docker-image
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/legg-til-sentry'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/slett-kriterier'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/src/App.less
+++ b/src/App.less
@@ -48,6 +48,10 @@
         grid-template-columns: 19rem 1fr;
         column-gap: 3rem;
         max-width: 74.125rem;
+
+        &__antall-stillinger {
+            padding-bottom: 2.5rem;
+        }
     }
 
     @media (min-width: @screen-lg-min) {

--- a/src/App.less
+++ b/src/App.less
@@ -50,7 +50,8 @@
         max-width: 74.125rem;
 
         &__antall-stillinger {
-            padding-bottom: 2.5rem;
+            // Denne er ganske presis for å aligne med toppen av søkefeltet
+            padding-bottom: 2.25rem;
         }
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,10 @@ import React, { FunctionComponent, useEffect, useState } from 'react';
 import { History } from 'history';
 import { Respons } from './elasticSearchTyper';
 import {
-    byggUrlMedParam,
     hentSøkekriterier,
     QueryParam,
     Navigeringsstate,
+    oppdaterUrlMedParam,
 } from './søk/søkefelt/urlUtils';
 import { lagQuery } from './api/queries/queries';
 import { søk } from './api/api';
@@ -52,8 +52,11 @@ const App: FunctionComponent<AppProps> = ({ navKontor, history }) => {
         const resetSidetall = !harByttetSide && søkekriterier.side > 1;
 
         if (resetSidetall) {
-            const { search } = byggUrlMedParam(QueryParam.Side, null);
-            history.replace({ search });
+            oppdaterUrlMedParam({
+                history,
+                parameter: QueryParam.Side,
+                verdi: null,
+            });
         } else {
             const søkMedUrl = async () => {
                 setRespons(await søk(lagQuery(søkekriterier)));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,11 +58,9 @@ const App: FunctionComponent<AppProps> = ({ navKontor, history }) => {
                 verdi: null,
             });
         } else {
-            const søkMedUrl = async () => {
-                setRespons(await søk(lagQuery(søkekriterier)));
-            };
-
-            søkMedUrl();
+            søk(lagQuery(søkekriterier)).then((respons) => {
+                setRespons(respons);
+            });
         }
     }, [search, history, navigeringsstate]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,11 @@ const App: FunctionComponent<AppProps> = ({ navKontor, history }) => {
         søkBasertPåUrl();
     };
 
+    const slettKriterier = () => {
+        oppdaterSearchParams('');
+        søkBasertPåUrl();
+    };
+
     const oppdaterSearchParams = (search: string) => {
         history.replace({ search });
     };
@@ -90,7 +95,7 @@ const App: FunctionComponent<AppProps> = ({ navKontor, history }) => {
             <Introduksjon />
 
             <aside className="app__sidepanel">
-                <Søk oppdaterSøk={oppdaterSøk} />
+                <Søk oppdaterSøk={oppdaterSøk} slettKriterier={slettKriterier} />
             </aside>
 
             <main className="app__søkeresultat">

--- a/src/paginering/Paginering.tsx
+++ b/src/paginering/Paginering.tsx
@@ -3,17 +3,16 @@ import { HoyreChevron, VenstreChevron } from 'nav-frontend-chevron';
 import ReactPaginate from 'react-paginate';
 
 import { maksAntallTreffPerSøk } from '../api/queries/queries';
-import { hentSøkekriterier, QueryParam } from '../søk/søkefelt/urlUtils';
+import { byggUrlMedParam, hentSøkekriterier, QueryParam } from '../søk/søkefelt/urlUtils';
 import { useHistory } from 'react-router-dom';
-import { SøkProps } from '../søk/Søk';
 import { Enhetstype, useEnhetstype } from '../utils/skjermUtils';
 import './Paginering.less';
 
-type Props = SøkProps & {
+type Props = {
     totaltAntallTreff: number;
 };
 
-const Paginering: FunctionComponent<Props> = ({ oppdaterSøk, totaltAntallTreff }) => {
+const Paginering: FunctionComponent<Props> = ({ totaltAntallTreff }) => {
     const history = useHistory();
     const { search } = history.location;
     const [side, setSide] = useState<number>(hentSøkekriterier(search).side);
@@ -36,7 +35,9 @@ const Paginering: FunctionComponent<Props> = ({ oppdaterSøk, totaltAntallTreff 
     const onPageChange = (valgtSide: number) => {
         setSkalScrolleTilToppen(true);
         setSide(valgtSide);
-        oppdaterSøk(QueryParam.Side, valgtSide === 1 ? null : valgtSide);
+
+        const { search } = byggUrlMedParam(QueryParam.Side, valgtSide === 1 ? null : valgtSide);
+        history.replace({ search, state: { harByttetSide: true } });
     };
 
     const antallSider = regnUtAntallSider(totaltAntallTreff, maksAntallTreffPerSøk);

--- a/src/paginering/Paginering.tsx
+++ b/src/paginering/Paginering.tsx
@@ -3,7 +3,7 @@ import { HoyreChevron, VenstreChevron } from 'nav-frontend-chevron';
 import ReactPaginate from 'react-paginate';
 
 import { maksAntallTreffPerSøk } from '../api/queries/queries';
-import { byggUrlMedParam, hentSøkekriterier, QueryParam } from '../søk/søkefelt/urlUtils';
+import { oppdaterUrlMedParam, hentSøkekriterier, QueryParam } from '../søk/søkefelt/urlUtils';
 import { useHistory } from 'react-router-dom';
 import { Enhetstype, useEnhetstype } from '../utils/skjermUtils';
 import './Paginering.less';
@@ -36,8 +36,14 @@ const Paginering: FunctionComponent<Props> = ({ totaltAntallTreff }) => {
         setSkalScrolleTilToppen(true);
         setSide(valgtSide);
 
-        const { search } = byggUrlMedParam(QueryParam.Side, valgtSide === 1 ? null : valgtSide);
-        history.replace({ search, state: { harByttetSide: true } });
+        oppdaterUrlMedParam({
+            history,
+            parameter: QueryParam.Side,
+            verdi: valgtSide === 1 ? null : valgtSide,
+            state: {
+                harByttetSide: true,
+            },
+        });
     };
 
     const antallSider = regnUtAntallSider(totaltAntallTreff, maksAntallTreffPerSøk);

--- a/src/søk/Søk.less
+++ b/src/søk/Søk.less
@@ -1,7 +1,9 @@
 @import '../variabler.less';
 
 .søk {
-    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
 
     &__ekspanderbart-panel {
         margin-top: 1rem;

--- a/src/søk/Søk.tsx
+++ b/src/søk/Søk.tsx
@@ -6,14 +6,20 @@ import OmAnnonsen from './om-annonsen/OmAnnonsen';
 import { erIkkeProd } from '../utils/featureToggleUtils';
 import Inkludering from './inkludering/Inkludering';
 import './Søk.less';
+import SlettKriterier from './slett-kriterier/SlettKriterier';
 
 export type SøkProps = {
     oppdaterSøk: (queryParam: QueryParam, verdi: QueryParamValue) => void;
 };
 
-const Søk: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
+type Props = SøkProps & {
+    slettKriterier: () => void;
+};
+
+const Søk: FunctionComponent<Props> = ({ oppdaterSøk, slettKriterier }) => {
     return (
         <div className="søk">
+            <SlettKriterier slettKriterier={slettKriterier} />
             <Søkefelt oppdaterSøk={oppdaterSøk} />
             <OmAnnonsen oppdaterSøk={oppdaterSøk} />
             <FylkerOgKommuner oppdaterSøk={oppdaterSøk} />

--- a/src/søk/Søk.tsx
+++ b/src/søk/Søk.tsx
@@ -1,29 +1,20 @@
 import React, { FunctionComponent } from 'react';
 import Søkefelt from './søkefelt/Søkefelt';
-import { QueryParam, QueryParamValue } from './søkefelt/urlUtils';
 import FylkerOgKommuner from './geografi/FylkerOgKommuner';
 import OmAnnonsen from './om-annonsen/OmAnnonsen';
 import { erIkkeProd } from '../utils/featureToggleUtils';
 import Inkludering from './inkludering/Inkludering';
-import './Søk.less';
 import SlettKriterier from './slett-kriterier/SlettKriterier';
+import './Søk.less';
 
-export type SøkProps = {
-    oppdaterSøk: (queryParam: QueryParam, verdi: QueryParamValue) => void;
-};
-
-type Props = SøkProps & {
-    slettKriterier: () => void;
-};
-
-const Søk: FunctionComponent<Props> = ({ oppdaterSøk, slettKriterier }) => {
+const Søk: FunctionComponent = () => {
     return (
         <div className="søk">
-            <SlettKriterier slettKriterier={slettKriterier} />
-            <Søkefelt oppdaterSøk={oppdaterSøk} />
-            <OmAnnonsen oppdaterSøk={oppdaterSøk} />
-            <FylkerOgKommuner oppdaterSøk={oppdaterSøk} />
-            {erIkkeProd && <Inkludering oppdaterSøk={oppdaterSøk} />}
+            <SlettKriterier />
+            <Søkefelt />
+            <OmAnnonsen />
+            <FylkerOgKommuner />
+            {erIkkeProd && <Inkludering />}
         </div>
     );
 };

--- a/src/søk/geografi/FylkerOgKommuner.tsx
+++ b/src/søk/geografi/FylkerOgKommuner.tsx
@@ -3,7 +3,7 @@ import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { Enhetstype, hentEnhetstype } from '../../utils/skjermUtils';
 import { Checkbox, SkjemaGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
-import { byggUrlMedParam, hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
+import { hentSøkekriterier, oppdaterUrlMedParam, QueryParam } from '../søkefelt/urlUtils';
 import { useHistory, useLocation } from 'react-router-dom';
 import fylkerOgKommuner from './fylkerOgKommuner.json';
 import { sorterAlfabetiskPåNorsk } from '../../utils/stringUtils';
@@ -22,9 +22,12 @@ const FylkerOgKommuner: FunctionComponent = () => {
         setValgteKommuner(hentSøkekriterier(search).kommuner);
     }, [search]);
 
-    const oppdaterSøk = (queryParam: QueryParam, value: string[]) => {
-        const { search } = byggUrlMedParam(queryParam, value);
-        history.replace({ search });
+    const oppdaterSøk = (parameter: QueryParam, verdi: string[]) => {
+        oppdaterUrlMedParam({
+            history,
+            parameter,
+            verdi,
+        });
     };
 
     const onFylkeChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/søk/geografi/FylkerOgKommuner.tsx
+++ b/src/søk/geografi/FylkerOgKommuner.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, Fragment, FunctionComponent, useState } from 'react';
+import React, { ChangeEvent, Fragment, FunctionComponent, useEffect, useState } from 'react';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { Enhetstype, hentEnhetstype } from '../../utils/skjermUtils';
 import { SøkProps } from '../Søk';
@@ -17,6 +17,11 @@ const FylkerOgKommuner: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
         hentSøkekriterier(search).kommuner
     );
 
+    useEffect(() => {
+        setValgteFylker(hentSøkekriterier(search).fylker);
+        setValgteKommuner(hentSøkekriterier(search).kommuner);
+    }, [search]);
+
     const onFylkeChange = (event: ChangeEvent<HTMLInputElement>) => {
         const fylke = event.target.value;
         const fylker = new Set<string>(valgteFylker);
@@ -27,7 +32,6 @@ const FylkerOgKommuner: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
             fylker.delete(fylke);
 
             const kommuner = deaktiverKommunerIFylke(Array.from(valgteKommuner), fylke);
-            setValgteKommuner(new Set<string>(kommuner));
             oppdaterSøk(QueryParam.Kommuner, kommuner);
         }
 
@@ -45,7 +49,6 @@ const FylkerOgKommuner: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
             kommuner.delete(kommuneMedFylke);
         }
 
-        setValgteKommuner(kommuner);
         oppdaterSøk(QueryParam.Kommuner, Array.from(kommuner));
     };
 

--- a/src/søk/geografi/FylkerOgKommuner.tsx
+++ b/src/søk/geografi/FylkerOgKommuner.tsx
@@ -1,15 +1,15 @@
 import React, { ChangeEvent, Fragment, FunctionComponent, useEffect, useState } from 'react';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { Enhetstype, hentEnhetstype } from '../../utils/skjermUtils';
-import { SøkProps } from '../Søk';
 import { Checkbox, SkjemaGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
-import { hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
-import { useLocation } from 'react-router-dom';
+import { byggUrlMedParam, hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
+import { useHistory, useLocation } from 'react-router-dom';
 import fylkerOgKommuner from './fylkerOgKommuner.json';
 import { sorterAlfabetiskPåNorsk } from '../../utils/stringUtils';
 
-const FylkerOgKommuner: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
+const FylkerOgKommuner: FunctionComponent = () => {
+    const history = useHistory();
     const { search } = useLocation();
 
     const [valgteFylker, setValgteFylker] = useState<Set<string>>(hentSøkekriterier(search).fylker);
@@ -21,6 +21,11 @@ const FylkerOgKommuner: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
         setValgteFylker(hentSøkekriterier(search).fylker);
         setValgteKommuner(hentSøkekriterier(search).kommuner);
     }, [search]);
+
+    const oppdaterSøk = (queryParam: QueryParam, value: string[]) => {
+        const { search } = byggUrlMedParam(queryParam, value);
+        history.replace({ search });
+    };
 
     const onFylkeChange = (event: ChangeEvent<HTMLInputElement>) => {
         const fylke = event.target.value;

--- a/src/søk/inkludering/Inkludering.tsx
+++ b/src/søk/inkludering/Inkludering.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, ChangeEvent, useState, useEffect } from 'reac
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { Checkbox } from 'nav-frontend-skjema';
 import { Enhetstype, hentEnhetstype } from '../../utils/skjermUtils';
-import { byggUrlMedParam, hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
+import { hentSøkekriterier, oppdaterUrlMedParam, QueryParam } from '../søkefelt/urlUtils';
 import { useHistory, useLocation } from 'react-router-dom';
 
 const Inkludering: FunctionComponent = () => {
@@ -22,8 +22,11 @@ const Inkludering: FunctionComponent = () => {
 
         setHarInkluderingsmulighet(checked);
 
-        const { search } = byggUrlMedParam(QueryParam.Inkludering, checked);
-        history.replace({ search });
+        oppdaterUrlMedParam({
+            history,
+            parameter: QueryParam.Inkludering,
+            verdi: checked,
+        });
     };
 
     return (

--- a/src/søk/inkludering/Inkludering.tsx
+++ b/src/søk/inkludering/Inkludering.tsx
@@ -2,11 +2,11 @@ import React, { FunctionComponent, ChangeEvent, useState, useEffect } from 'reac
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { Checkbox } from 'nav-frontend-skjema';
 import { Enhetstype, hentEnhetstype } from '../../utils/skjermUtils';
-import { hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
-import { useLocation } from 'react-router-dom';
-import { SøkProps } from '../Søk';
+import { byggUrlMedParam, hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
+import { useHistory, useLocation } from 'react-router-dom';
 
-const Inkludering: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
+const Inkludering: FunctionComponent = () => {
+    const history = useHistory();
     const { search } = useLocation();
 
     const [harInkluderingsmulighet, setHarInkluderingsmulighet] = useState<boolean>(
@@ -21,7 +21,9 @@ const Inkludering: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
         const checked = event.target.checked;
 
         setHarInkluderingsmulighet(checked);
-        oppdaterSøk(QueryParam.Inkludering, checked);
+
+        const { search } = byggUrlMedParam(QueryParam.Inkludering, checked);
+        history.replace({ search });
     };
 
     return (

--- a/src/søk/inkludering/Inkludering.tsx
+++ b/src/søk/inkludering/Inkludering.tsx
@@ -1,17 +1,21 @@
-import React, { FunctionComponent, ChangeEvent, useState } from 'react';
+import React, { FunctionComponent, ChangeEvent, useState, useEffect } from 'react';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { Checkbox } from 'nav-frontend-skjema';
 import { Enhetstype, hentEnhetstype } from '../../utils/skjermUtils';
 import { hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
-import { useHistory } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { SøkProps } from '../Søk';
 
 const Inkludering: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
-    const history = useHistory();
+    const { search } = useLocation();
 
     const [harInkluderingsmulighet, setHarInkluderingsmulighet] = useState<boolean>(
-        hentSøkekriterier(history.location.search).inkludering
+        hentSøkekriterier(search).inkludering
     );
+
+    useEffect(() => {
+        setHarInkluderingsmulighet(hentSøkekriterier(search).inkludering);
+    }, [search]);
 
     const onInkluderingChange = (event: ChangeEvent<HTMLInputElement>) => {
         const checked = event.target.checked;

--- a/src/søk/om-annonsen/Annonsestatus.tsx
+++ b/src/søk/om-annonsen/Annonsestatus.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, FunctionComponent, useEffect, useState } from 'react';
 import { Checkbox, SkjemaGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
-import { byggUrlMedParam, hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
+import { hentSøkekriterier, oppdaterUrlMedParam, QueryParam } from '../søkefelt/urlUtils';
 import { useHistory, useLocation } from 'react-router-dom';
 
 export enum Status {
@@ -31,8 +31,11 @@ const Annonsestatus: FunctionComponent = () => {
             statuser.delete(status);
         }
 
-        const { search } = byggUrlMedParam(QueryParam.Statuser, Array.from(statuser));
-        history.replace({ search });
+        oppdaterUrlMedParam({
+            history,
+            parameter: QueryParam.Statuser,
+            verdi: Array.from(statuser),
+        });
     };
 
     return (

--- a/src/søk/om-annonsen/Annonsestatus.tsx
+++ b/src/søk/om-annonsen/Annonsestatus.tsx
@@ -1,9 +1,9 @@
-import React, { ChangeEvent, FunctionComponent, useState } from 'react';
+import React, { ChangeEvent, FunctionComponent, useEffect, useState } from 'react';
 import { Checkbox, SkjemaGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
 import { hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
 import { SøkProps } from '../Søk';
-import { useHistory } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 export enum Status {
     Publisert = 'publisert',
@@ -12,11 +12,14 @@ export enum Status {
 }
 
 const Annonsestatus: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
-    // TODO default
-    const history = useHistory();
+    const { search } = useLocation();
     const [valgteStatuser, setValgteStatuser] = useState<Set<Status>>(
-        hentSøkekriterier(history.location.search).statuser
+        hentSøkekriterier(search).statuser
     );
+
+    useEffect(() => {
+        setValgteStatuser(hentSøkekriterier(search).statuser);
+    }, [search]);
 
     const onAnnonsestatusChange = (event: ChangeEvent<HTMLInputElement>) => {
         const status = event.target.value as Status;
@@ -27,7 +30,7 @@ const Annonsestatus: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
         } else {
             statuser.delete(status);
         }
-        setValgteStatuser(statuser);
+
         oppdaterSøk(QueryParam.Statuser, Array.from(statuser));
     };
 

--- a/src/søk/om-annonsen/Annonsestatus.tsx
+++ b/src/søk/om-annonsen/Annonsestatus.tsx
@@ -1,9 +1,8 @@
 import React, { ChangeEvent, FunctionComponent, useEffect, useState } from 'react';
 import { Checkbox, SkjemaGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
-import { hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
-import { SøkProps } from '../Søk';
-import { useLocation } from 'react-router-dom';
+import { byggUrlMedParam, hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
+import { useHistory, useLocation } from 'react-router-dom';
 
 export enum Status {
     Publisert = 'publisert',
@@ -11,7 +10,8 @@ export enum Status {
     Utløpt = 'utløpt',
 }
 
-const Annonsestatus: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
+const Annonsestatus: FunctionComponent = () => {
+    const history = useHistory();
     const { search } = useLocation();
     const [valgteStatuser, setValgteStatuser] = useState<Set<Status>>(
         hentSøkekriterier(search).statuser
@@ -31,7 +31,8 @@ const Annonsestatus: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
             statuser.delete(status);
         }
 
-        oppdaterSøk(QueryParam.Statuser, Array.from(statuser));
+        const { search } = byggUrlMedParam(QueryParam.Statuser, Array.from(statuser));
+        history.replace({ search });
     };
 
     return (

--- a/src/søk/om-annonsen/HvorErAnnonsenPublisert.tsx
+++ b/src/søk/om-annonsen/HvorErAnnonsenPublisert.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, FunctionComponent, useState } from 'react';
 import { Checkbox, SkjemaGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
 import { useHistory, useLocation } from 'react-router-dom';
-import { byggUrlMedParam, hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
+import { hentSøkekriterier, oppdaterUrlMedParam, QueryParam } from '../søkefelt/urlUtils';
 import '../Søk.less';
 
 export enum Publisert {
@@ -38,17 +38,18 @@ const HvorErAnnonsenPublisert: FunctionComponent = () => {
     };
 
     const settIUrlOgSøk = (interntINav: boolean, påArbeidsplassen: boolean) => {
-        let url;
+        let verdi =
+            interntINav === påArbeidsplassen
+                ? null
+                : interntINav
+                ? Publisert.Intern
+                : Publisert.Arbeidsplassen;
 
-        if (interntINav === påArbeidsplassen) {
-            url = byggUrlMedParam(QueryParam.Publisert, null);
-        } else if (interntINav) {
-            url = byggUrlMedParam(QueryParam.Publisert, Publisert.Intern);
-        } else {
-            url = byggUrlMedParam(QueryParam.Publisert, Publisert.Arbeidsplassen);
-        }
-
-        history.replace({ search: url.search });
+        oppdaterUrlMedParam({
+            history,
+            parameter: QueryParam.Publisert,
+            verdi,
+        });
     };
 
     return (

--- a/src/søk/om-annonsen/HvorErAnnonsenPublisert.tsx
+++ b/src/søk/om-annonsen/HvorErAnnonsenPublisert.tsx
@@ -1,9 +1,8 @@
-import React, { ChangeEvent, FunctionComponent, useEffect, useState } from 'react';
+import React, { ChangeEvent, FunctionComponent, useState } from 'react';
 import { Checkbox, SkjemaGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
-import { useLocation } from 'react-router-dom';
-import { hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
-import { SøkProps } from '../Søk';
+import { useHistory, useLocation } from 'react-router-dom';
+import { byggUrlMedParam, hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
 import '../Søk.less';
 
 export enum Publisert {
@@ -15,7 +14,8 @@ export enum Publisert {
 const matcherPublisertIUrl = (publisert: Publisert, searchParams: string) =>
     hentSøkekriterier(searchParams).publisert === publisert;
 
-const HvorErAnnonsenPublisert: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
+const HvorErAnnonsenPublisert: FunctionComponent = () => {
+    const history = useHistory();
     const { search } = useLocation();
 
     const [interntINav, setInterntINav] = useState<boolean>(
@@ -24,11 +24,6 @@ const HvorErAnnonsenPublisert: FunctionComponent<SøkProps> = ({ oppdaterSøk })
     const [påArbeidsplassen, setPåArbeidsplassen] = useState<boolean>(
         matcherPublisertIUrl(Publisert.Arbeidsplassen, search)
     );
-
-    useEffect(() => {
-        setInterntINav(matcherPublisertIUrl(Publisert.Intern, search));
-        setPåArbeidsplassen(matcherPublisertIUrl(Publisert.Arbeidsplassen, search));
-    }, [search]);
 
     const onPublisertChange = (event: ChangeEvent<HTMLInputElement>) => {
         const { checked } = event.target;
@@ -43,13 +38,17 @@ const HvorErAnnonsenPublisert: FunctionComponent<SøkProps> = ({ oppdaterSøk })
     };
 
     const settIUrlOgSøk = (interntINav: boolean, påArbeidsplassen: boolean) => {
+        let url;
+
         if (interntINav === påArbeidsplassen) {
-            oppdaterSøk(QueryParam.Publisert, null);
+            url = byggUrlMedParam(QueryParam.Publisert, null);
         } else if (interntINav) {
-            oppdaterSøk(QueryParam.Publisert, Publisert.Intern);
+            url = byggUrlMedParam(QueryParam.Publisert, Publisert.Intern);
         } else {
-            oppdaterSøk(QueryParam.Publisert, Publisert.Arbeidsplassen);
+            url = byggUrlMedParam(QueryParam.Publisert, Publisert.Arbeidsplassen);
         }
+
+        history.replace({ search: url.search });
     };
 
     return (

--- a/src/søk/om-annonsen/HvorErAnnonsenPublisert.tsx
+++ b/src/søk/om-annonsen/HvorErAnnonsenPublisert.tsx
@@ -1,8 +1,13 @@
-import React, { ChangeEvent, FunctionComponent, useState } from 'react';
+import React, { ChangeEvent, FunctionComponent, useEffect, useState } from 'react';
 import { Checkbox, SkjemaGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
 import { useHistory, useLocation } from 'react-router-dom';
-import { hentSøkekriterier, oppdaterUrlMedParam, QueryParam } from '../søkefelt/urlUtils';
+import {
+    hentSøkekriterier,
+    Navigeringsstate,
+    oppdaterUrlMedParam,
+    QueryParam,
+} from '../søkefelt/urlUtils';
 import '../Søk.less';
 
 export enum Publisert {
@@ -16,7 +21,7 @@ const matcherPublisertIUrl = (publisert: Publisert, searchParams: string) =>
 
 const HvorErAnnonsenPublisert: FunctionComponent = () => {
     const history = useHistory();
-    const { search } = useLocation();
+    const { search, state } = useLocation<Navigeringsstate>();
 
     const [interntINav, setInterntINav] = useState<boolean>(
         matcherPublisertIUrl(Publisert.Intern, search)
@@ -24,6 +29,13 @@ const HvorErAnnonsenPublisert: FunctionComponent = () => {
     const [påArbeidsplassen, setPåArbeidsplassen] = useState<boolean>(
         matcherPublisertIUrl(Publisert.Arbeidsplassen, search)
     );
+
+    useEffect(() => {
+        if (state?.harSlettetKriterier) {
+            setInterntINav(false);
+            setPåArbeidsplassen(false);
+        }
+    }, [search, state, interntINav, påArbeidsplassen]);
 
     const onPublisertChange = (event: ChangeEvent<HTMLInputElement>) => {
         const { checked } = event.target;

--- a/src/søk/om-annonsen/HvorErAnnonsenPublisert.tsx
+++ b/src/søk/om-annonsen/HvorErAnnonsenPublisert.tsx
@@ -1,7 +1,7 @@
-import React, { ChangeEvent, FunctionComponent, useState } from 'react';
+import React, { ChangeEvent, FunctionComponent, useEffect, useState } from 'react';
 import { Checkbox, SkjemaGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
-import { useHistory } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { hentSøkekriterier, QueryParam } from '../søkefelt/urlUtils';
 import { SøkProps } from '../Søk';
 import '../Søk.less';
@@ -16,8 +16,7 @@ const matcherPublisertIUrl = (publisert: Publisert, searchParams: string) =>
     hentSøkekriterier(searchParams).publisert === publisert;
 
 const HvorErAnnonsenPublisert: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
-    const history = useHistory();
-    const search = history.location.search;
+    const { search } = useLocation();
 
     const [interntINav, setInterntINav] = useState<boolean>(
         matcherPublisertIUrl(Publisert.Intern, search)
@@ -25,6 +24,11 @@ const HvorErAnnonsenPublisert: FunctionComponent<SøkProps> = ({ oppdaterSøk })
     const [påArbeidsplassen, setPåArbeidsplassen] = useState<boolean>(
         matcherPublisertIUrl(Publisert.Arbeidsplassen, search)
     );
+
+    useEffect(() => {
+        setInterntINav(matcherPublisertIUrl(Publisert.Intern, search));
+        setPåArbeidsplassen(matcherPublisertIUrl(Publisert.Arbeidsplassen, search));
+    }, [search]);
 
     const onPublisertChange = (event: ChangeEvent<HTMLInputElement>) => {
         const { checked } = event.target;

--- a/src/søk/om-annonsen/OmAnnonsen.tsx
+++ b/src/søk/om-annonsen/OmAnnonsen.tsx
@@ -1,19 +1,18 @@
 import React, { FunctionComponent } from 'react';
-import { SøkProps } from '../Søk';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { Enhetstype, hentEnhetstype } from '../../utils/skjermUtils';
 import Annonsestatus from './Annonsestatus';
 import HvorErAnnonsenPublisert from './HvorErAnnonsenPublisert';
 
-const OmAnnonsen: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
+const OmAnnonsen: FunctionComponent = () => {
     return (
         <Ekspanderbartpanel
             apen={enhetstype === Enhetstype.Desktop}
             tittel="Om annonsen"
             className="søk__ekspanderbart-panel"
         >
-            <Annonsestatus oppdaterSøk={oppdaterSøk} />
-            <HvorErAnnonsenPublisert oppdaterSøk={oppdaterSøk} />
+            <Annonsestatus />
+            <HvorErAnnonsenPublisert />
         </Ekspanderbartpanel>
     );
 };

--- a/src/søk/slett-kriterier/SlettKriterier.less
+++ b/src/søk/slett-kriterier/SlettKriterier.less
@@ -1,4 +1,9 @@
 .slett-kriterier {
-    align-self: flex-end;
     border: none;
+    align-self: flex-end;
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: underline;
+    }
 }

--- a/src/søk/slett-kriterier/SlettKriterier.less
+++ b/src/søk/slett-kriterier/SlettKriterier.less
@@ -1,0 +1,4 @@
+.slett-kriterier {
+    align-self: flex-end;
+    border: none;
+}

--- a/src/søk/slett-kriterier/SlettKriterier.tsx
+++ b/src/søk/slett-kriterier/SlettKriterier.tsx
@@ -1,12 +1,26 @@
 import React, { FunctionComponent } from 'react';
 import { Element } from 'nav-frontend-typografi';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import './SlettKriterier.less';
+import { Navigeringsstate } from '../søkefelt/urlUtils';
 
-const SlettKriterier: FunctionComponent = () => (
-    <Link to="/stillingssok" className="slett-kriterier lenke">
-        <Element>Slett kriterier</Element>
-    </Link>
-);
+const SlettKriterier: FunctionComponent = () => {
+    const { pathname } = useLocation<Navigeringsstate>();
+
+    return (
+        <Link
+            to={{
+                pathname,
+                search: '',
+                state: {
+                    harSlettetKriterier: true,
+                },
+            }}
+            className="slett-kriterier lenke"
+        >
+            <Element>Slett kriterier</Element>
+        </Link>
+    );
+};
 
 export default SlettKriterier;

--- a/src/søk/slett-kriterier/SlettKriterier.tsx
+++ b/src/søk/slett-kriterier/SlettKriterier.tsx
@@ -1,0 +1,18 @@
+import React, { FunctionComponent } from 'react';
+import { Element } from 'nav-frontend-typografi';
+import { Link } from 'react-router-dom';
+import './SlettKriterier.less';
+
+type Props = {
+    slettKriterier: () => void;
+};
+
+const SlettKriterier: FunctionComponent<Props> = ({ slettKriterier }) => {
+    return (
+        <Link onClick={slettKriterier} to="/stillingssok" className="slett-kriterier lenke">
+            <Element>Slett kriterier</Element>
+        </Link>
+    );
+};
+
+export default SlettKriterier;

--- a/src/søk/slett-kriterier/SlettKriterier.tsx
+++ b/src/søk/slett-kriterier/SlettKriterier.tsx
@@ -3,16 +3,10 @@ import { Element } from 'nav-frontend-typografi';
 import { Link } from 'react-router-dom';
 import './SlettKriterier.less';
 
-type Props = {
-    slettKriterier: () => void;
-};
-
-const SlettKriterier: FunctionComponent<Props> = ({ slettKriterier }) => {
-    return (
-        <Link onClick={slettKriterier} to="/stillingssok" className="slett-kriterier lenke">
-            <Element>Slett kriterier</Element>
-        </Link>
-    );
-};
+const SlettKriterier: FunctionComponent = () => (
+    <Link to="/stillingssok" className="slett-kriterier lenke">
+        <Element>Slett kriterier</Element>
+    </Link>
+);
 
 export default SlettKriterier;

--- a/src/søk/søkefelt/Søkefelt.tsx
+++ b/src/søk/søkefelt/Søkefelt.tsx
@@ -2,17 +2,19 @@ import React, { ChangeEvent, FormEvent, FunctionComponent, useEffect, useState }
 import { Søkeknapp } from 'nav-frontend-ikonknapper';
 import { Input } from 'nav-frontend-skjema';
 import { useHistory, useLocation } from 'react-router-dom';
-import { hentSøkekriterier, oppdaterUrlMedParam, QueryParam } from './urlUtils';
+import { hentSøkekriterier, Navigeringsstate, oppdaterUrlMedParam, QueryParam } from './urlUtils';
 import './Søkefelt.less';
 
 const Søkefelt: FunctionComponent = () => {
     const history = useHistory();
-    const { search } = useLocation();
+    const { search, state } = useLocation<Navigeringsstate>();
     const [input, setInput] = useState<string>(hentSøkekriterier(search).tekst);
 
     useEffect(() => {
-        setInput(hentSøkekriterier(search).tekst);
-    }, [search]);
+        if (state?.harSlettetKriterier) {
+            setInput('');
+        }
+    }, [search, state]);
 
     const onInputChange = (event: ChangeEvent<HTMLInputElement>) => {
         setInput(event.target.value);

--- a/src/søk/søkefelt/Søkefelt.tsx
+++ b/src/søk/søkefelt/Søkefelt.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, FormEvent, FunctionComponent, useEffect, useState }
 import { Søkeknapp } from 'nav-frontend-ikonknapper';
 import { Input } from 'nav-frontend-skjema';
 import { useHistory, useLocation } from 'react-router-dom';
-import { byggUrlMedParam, hentSøkekriterier, QueryParam } from './urlUtils';
+import { hentSøkekriterier, oppdaterUrlMedParam, QueryParam } from './urlUtils';
 import './Søkefelt.less';
 
 const Søkefelt: FunctionComponent = () => {
@@ -21,8 +21,11 @@ const Søkefelt: FunctionComponent = () => {
     const onSubmit = (event: FormEvent) => {
         event.preventDefault();
 
-        const { search } = byggUrlMedParam(QueryParam.Tekst, input);
-        history.replace({ search });
+        oppdaterUrlMedParam({
+            history,
+            parameter: QueryParam.Tekst,
+            verdi: input,
+        });
     };
 
     return (

--- a/src/søk/søkefelt/Søkefelt.tsx
+++ b/src/søk/søkefelt/Søkefelt.tsx
@@ -1,14 +1,18 @@
-import React, { ChangeEvent, FormEvent, FunctionComponent, useState } from 'react';
+import React, { ChangeEvent, FormEvent, FunctionComponent, useEffect, useState } from 'react';
 import { Søkeknapp } from 'nav-frontend-ikonknapper';
 import { Input } from 'nav-frontend-skjema';
-import { useLocation } from 'react-router-dom';
-import { hentSøkekriterier, QueryParam } from './urlUtils';
-import { SøkProps } from '../Søk';
+import { useHistory, useLocation } from 'react-router-dom';
+import { byggUrlMedParam, hentSøkekriterier, QueryParam } from './urlUtils';
 import './Søkefelt.less';
 
-const Søkefelt: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
+const Søkefelt: FunctionComponent = () => {
+    const history = useHistory();
     const { search } = useLocation();
     const [input, setInput] = useState<string>(hentSøkekriterier(search).tekst);
+
+    useEffect(() => {
+        setInput(hentSøkekriterier(search).tekst);
+    }, [search]);
 
     const onInputChange = (event: ChangeEvent<HTMLInputElement>) => {
         setInput(event.target.value);
@@ -16,7 +20,9 @@ const Søkefelt: FunctionComponent<SøkProps> = ({ oppdaterSøk }) => {
 
     const onSubmit = (event: FormEvent) => {
         event.preventDefault();
-        oppdaterSøk(QueryParam.Tekst, input);
+
+        const { search } = byggUrlMedParam(QueryParam.Tekst, input);
+        history.replace({ search });
     };
 
     return (

--- a/src/søk/søkefelt/urlUtils.ts
+++ b/src/søk/søkefelt/urlUtils.ts
@@ -12,6 +12,12 @@ export enum QueryParam {
     Inkludering = 'inkludering',
 }
 
+export type Navigeringsstate =
+    | {
+          harByttetSide: boolean;
+      }
+    | undefined;
+
 export type QueryParamValue = string | boolean | null | number | string[];
 
 export const hentSøkekriterier = (search: string): Søkekriterier => {

--- a/src/søk/søkefelt/urlUtils.ts
+++ b/src/søk/søkefelt/urlUtils.ts
@@ -15,7 +15,8 @@ export enum QueryParam {
 
 export type Navigeringsstate =
     | {
-          harByttetSide: boolean;
+          harByttetSide?: boolean;
+          harSlettetKriterier?: boolean;
       }
     | undefined;
 

--- a/src/søk/søkefelt/urlUtils.ts
+++ b/src/søk/søkefelt/urlUtils.ts
@@ -1,6 +1,7 @@
 import { Søkekriterier } from '../../App';
 import { Publisert } from '../om-annonsen/HvorErAnnonsenPublisert';
 import { Status } from '../om-annonsen/Annonsestatus';
+import { History } from 'history';
 
 export enum QueryParam {
     Tekst = 'q',
@@ -64,4 +65,19 @@ export const byggUrlMedParam = (param: QueryParam, value: QueryParamValue) => {
     }
 
     return url;
+};
+
+export const oppdaterUrlMedParam = ({
+    history,
+    parameter,
+    verdi,
+    state,
+}: {
+    parameter: QueryParam;
+    verdi: QueryParamValue;
+    history: History;
+    state?: Navigeringsstate;
+}) => {
+    const { search } = byggUrlMedParam(parameter, verdi);
+    history.replace({ search, state });
 };


### PR DESCRIPTION
Legg til knapp for å slette søkekriterier.

Sleit litt med å gjøre det elegant med strukturen for `oppdaterSøk` fra filtre til App.tsx. Så prøvde å endre tilbake til  slik vi hadde det før, hvor søk kun trigges av endringer i URL. Fant _the missing piece_ i denne logikken, som var å utnytte _State_ i [History API-et](https://developer.mozilla.org/en-US/docs/Web/API/History_API/Working_with_the_History_API). Da ble sideblaing uten dobbeltsøk plutselig enkelt igjen.

Fra tegning over, til tegningen under:
![image](https://user-images.githubusercontent.com/8887917/107570720-36275a00-6bea-11eb-9a6a-95529c2188d7.png)
