### PR TITLE
Send respons innnhold til Sentry når søke-request feiler

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -10,7 +10,9 @@ export const søk = async (query: Query): Promise<Respons> => {
     const respons = await post(`${stillingssøkProxy}/stilling/_search`, query);
 
     if (respons.status !== 200) {
-        throw Error('Klarte ikke å gjøre et søk');
+        throw Error(
+            `Klarte ikke å gjøre et søk. HTTP respons status: ${respons.status}, HTTP respons tekst: ${respons.statusText}, URL: ${respons.url}`
+        );
     }
 
     return respons.json();


### PR DESCRIPTION
istedenfor bare "Klarte ikke gjøre et søk".

Det er slik jeg ville logget i Java/Kotlin. Er det en forbedring her? Gjorde det fordi jeg ikke ble så mye klokere av å se i Sentry på alert i Slack #inkludering-alerts-sentry. Men kanskje er det jeg som ikke vet å bruke Sentry riktig?